### PR TITLE
[IMP] sale_order_blanket_order: allow blanket order overlap for specific products

### DIFF
--- a/sale_order_blanket_order/README.rst
+++ b/sale_order_blanket_order/README.rst
@@ -37,17 +37,17 @@ Blanket Order
 A Blanket Order is a standard sales order with the following specific
 features:
 
-- Type: Classified as "Blanket Order".
-- Defined Duration: Includes a validity period (end date).
-- Payment Terms: Allows selection of preferred terms (e.g., 90 days end
-  of month, upon delivery, etc.).
-- Invoicing Policy: Can be based on product settings or the order
-  itself.
-- Stock Reservation: Allows advance reservation of sold quantities.
-- Handling Unfulfilled Quantities: Provides options for dealing with
-  undelivered quantities upon order expiration.
-- Prices are calculated based on existing rules since it is a standard
-  sales order type.
+-  Type: Classified as "Blanket Order".
+-  Defined Duration: Includes a validity period (end date).
+-  Payment Terms: Allows selection of preferred terms (e.g., 90 days end
+   of month, upon delivery, etc.).
+-  Invoicing Policy: Can be based on product settings or the order
+   itself.
+-  Stock Reservation: Allows advance reservation of sold quantities.
+-  Handling Unfulfilled Quantities: Provides options for dealing with
+   undelivered quantities upon order expiration.
+-  Prices are calculated based on existing rules since it is a standard
+   sales order type.
 
 The blanket order serves as the central element triggering stock
 management and invoicing mechanisms.
@@ -94,12 +94,12 @@ Call-off Order
 A Call-off Order is a standard sales order with these specific
 characteristics:
 
-- Type: Classified as "Call-off Order".
-- Linked to Blanket Order: Only includes products from the blanket
-  order.
-- Delivery Release: Enables the release of reserved stock for delivery.
-- No Invoicing or Stock Management: These are handled via the linked
-  blanket order.
+-  Type: Classified as "Call-off Order".
+-  Linked to Blanket Order: Only includes products from the blanket
+   order.
+-  Delivery Release: Enables the release of reserved stock for delivery.
+-  No Invoicing or Stock Management: These are handled via the linked
+   blanket order.
 
 Stock Management
 ----------------
@@ -108,8 +108,8 @@ No delivery is generated directly from the call-off order.
 
 It triggers:
 
-- Release of the reserved quantity in the blanket order.
-- Adjustment of stock reservations for the remaining quantities.
+-  Release of the reserved quantity in the blanket order.
+-  Adjustment of stock reservations for the remaining quantities.
 
 Standard Sales Orders
 =====================
@@ -137,9 +137,9 @@ that defines the terms and conditions of the sales.
 
 If you need a way to define:
 
-- the terms and conditions of the sales,
-- the payment terms,
-- the delivery terms,
+-  the terms and conditions of the sales,
+-  the payment terms,
+-  the delivery terms,
 
 and also secure the quantities of the products to be delivered, the sale
 order blanket order module is the right choice.
@@ -195,15 +195,15 @@ Authors
 Contributors
 ------------
 
-- Laurent Mignon\ laurent.mignon@acsone.eu (https://www.acsone.eu)
-- Jacques-Etienne Baudoux (BCIM) je@bcim.be
+-  Laurent Mignon\ laurent.mignon@acsone.eu (https://www.acsone.eu)
+-  Jacques-Etienne Baudoux (BCIM) je@bcim.be
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- ALCYON Belux
+-  ALCYON Belux
 
 Maintainers
 -----------

--- a/sale_order_blanket_order/__manifest__.py
+++ b/sale_order_blanket_order/__manifest__.py
@@ -13,6 +13,7 @@
     ],
     "excludes": ["sale_blanket_order"],
     "data": [
+        "views/product_template.xml",
         "views/sale_order.xml",
         "views/sale_order_line.xml",
         "views/res_config_settings.xml",

--- a/sale_order_blanket_order/models/__init__.py
+++ b/sale_order_blanket_order/models/__init__.py
@@ -4,3 +4,4 @@ from . import sale_order
 from . import sale_order_line
 from . import stock_move
 from . import stock_rule
+from . import product_template

--- a/sale_order_blanket_order/models/product_template.py
+++ b/sale_order_blanket_order/models/product_template.py
@@ -1,0 +1,14 @@
+# Copyright 2025 ACSONE SA/NV
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = "product.template"
+
+    allow_blanket_order_overlap = fields.Boolean(
+        help="If enabled, blanket orders for this product can have overlapping validity"
+        "periods. By default, overlap is not allowed, ensuring only one active blanket "
+        "order applies at a time.",
+    )

--- a/sale_order_blanket_order/models/sale_order_line.py
+++ b/sale_order_blanket_order/models/sale_order_line.py
@@ -200,6 +200,8 @@ class SaleOrderLine(models.Model):
             res = self.env.cr.fetchall()
             if res:
                 sol = self.browse(res[0][0])
+                if sol.product_id.allow_blanket_order_overlap:
+                    continue
                 raise ValidationError(
                     _(
                         "The product '%(product_name)s' is already part of another "

--- a/sale_order_blanket_order/tests/test_sale_blanket_order.py
+++ b/sale_order_blanket_order/tests/test_sale_blanket_order.py
@@ -89,6 +89,8 @@ class TestSaleBlanketOrder(SaleOrderBlanketOrderCase):
             ),
         ):
             order.action_confirm()
+        self.product_1.allow_blanket_order_overlap = True
+        order.action_confirm()
 
     def test_reservation(self):
         # Confirm the blanket order with reservation at call off

--- a/sale_order_blanket_order/views/product_template.xml
+++ b/sale_order_blanket_order/views/product_template.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2025 ACSONE SA/NV
+     License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl). -->
+<odoo>
+
+    <record model="ir.ui.view" id="product_template_form_view">
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="sale.product_template_form_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//page[@name='sales']" position="inside">
+                <group string="Blanket orders" name="blanket_order">
+                    <field name="allow_blanket_order_overlap" />
+                </group>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/sale_order_blanket_order_stock_prebook/README.rst
+++ b/sale_order_blanket_order_stock_prebook/README.rst
@@ -80,15 +80,15 @@ Authors
 Contributors
 ------------
 
-- Laurent Mignon\ laurent.mignon@acsone.eu (https://www.acsone.eu)
-- Jacques-Etienne Baudoux (BCIM) je@bcim.be
+-  Laurent Mignon\ laurent.mignon@acsone.eu (https://www.acsone.eu)
+-  Jacques-Etienne Baudoux (BCIM) je@bcim.be
 
 Other credits
 -------------
 
 The development of this module has been financially supported by:
 
-- ALCYON Belux
+-  ALCYON Belux
 
 Maintainers
 -----------


### PR DESCRIPTION
by default, blanket order overlap is not allowed, ensuring that only one active blanket order applies at a time.
however, for certain products like delivery services, overlapping blanket orders are normal and do not pose an issue.

this commit adds a bool field, allow_blanket_order_overlap, to the product model, allowing specific products to permit
overlapping blanket orders when enabled.

