### PR TITLE
[FIX] _compute_qty_to_deliver depends on order_type

### DIFF
--- a/sale_order_blanket_order/models/sale_order_line.py
+++ b/sale_order_blanket_order/models/sale_order_line.py
@@ -431,6 +431,7 @@ class SaleOrderLine(models.Model):
             line.qty_available_today = blanket_line.qty_available_today
         return res
 
+    @api.depends("order_type")
     def _compute_qty_to_deliver(self):
         # Overload to consider the call-off order lines in the computation
         # For these lines the qty to deliver is the same as the product_uom_qty


### PR DESCRIPTION
for call-off orders, `qty_to_deliver` is always 0. since it's a computed field, its method should depend on order_type.

without `order_type` in `@api.depends,` the compute method in `sale_order_blanket_order` may not be triggered, while the one in the base module is. This might seem insignificant since `qty_to_deliver` is not a stored field, but the hidden issue is that stored fields depending on it will not be flagged for recomputation after record creation

I didn't add a unit test as it's unclear how to reproduce this behavior. only 30 lines were affected out of 1200 call-off lines in the prod db

cc/ @lmignon 